### PR TITLE
Add txTo to Transfer entity + credit boughtCap on approved tx.to

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -19,6 +19,8 @@ type Transfer @entity(immutable: true) {
   tokenAddress: Bytes!
   from: Account!
   fromIsApprovedSource: Boolean!
+  txTo: Bytes # tx-level recipient (msg.sender's target) — used to detect aggregator-routed buys where Transfer.from is an intermediate
+  txToIsApprovedSource: Boolean!
   to: Account!
   value: BigInt!
   blockNumber: BigInt!

--- a/src/cys-flr.ts
+++ b/src/cys-flr.ts
@@ -1,7 +1,7 @@
 import { TOTALS_ID } from "./constants";
 import { takeSnapshot } from "./snapshot";
 import { getOrCreateAccount, isApprovedSource } from "./common";
-import { BigInt, Address } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import { handleLiquidityAdd, handleLiquidityWithdraw } from "./liquidity";
 import { Transfer as TransferEvent } from "../generated/templates/CycloVaultTemplate/CycloVault";
 import { Account, Transfer, EligibleTotals, CycloVault, VaultBalance } from "../generated/schema";
@@ -95,6 +95,27 @@ export function handleTransfer(event: TransferEvent): void {
   // Check if transfer is from approved source
   const fromIsApprovedSource = isApprovedSource(event.params.from);
 
+  // Also check the tx-level target — DEX aggregators (OpenOcean etc) may route
+  // through an intermediate contract so Transfer.from is an adapter rather than
+  // the aggregator itself. If the tx was sent TO an approved source, treat
+  // the recipient as buying from an approved source.
+  // Skip when fromIsApprovedSource already true (short-circuit), when txTo is
+  // null (contract creation), or when txTo is the cy token itself (direct
+  // token-contract call, never approved).
+  const txTo = event.transaction.to;
+  let txToIsApprovedSource = false;
+  if (
+    !fromIsApprovedSource &&
+    txTo !== null &&
+    (txTo as Bytes).notEqual(event.address)
+  ) {
+    txToIsApprovedSource = isApprovedSource(
+      changetype<Address>(txTo as Bytes),
+    );
+  }
+
+  const isApprovedBuy = fromIsApprovedSource || txToIsApprovedSource;
+
   // Detect LP operations (these have side effects: creating entities, updating LP balances)
   const isLpDeposit = handleLiquidityAdd(event, event.address);
   let lpWithdrawDeduction = BigInt.zero();
@@ -111,7 +132,7 @@ export function handleTransfer(event: TransferEvent): void {
     toVaultBalance.lpBalance = toVaultBalance.lpBalance.minus(lpWithdrawDeduction);
   } else {
     // Regular transfer: affects boughtCap
-    if (fromIsApprovedSource) {
+    if (isApprovedBuy) {
       toVaultBalance.boughtCap = toVaultBalance.boughtCap.plus(event.params.value);
     }
     fromVaultBalance.boughtCap = fromVaultBalance.boughtCap.minus(event.params.value);
@@ -151,6 +172,8 @@ export function handleTransfer(event: TransferEvent): void {
   );
   transfer.tokenAddress = event.address;
   transfer.fromIsApprovedSource = fromIsApprovedSource;
+  transfer.txTo = txTo;
+  transfer.txToIsApprovedSource = txToIsApprovedSource;
   transfer.from = fromAccount.id;
   transfer.to = toAccount.id;
   transfer.value = event.params.value;

--- a/tests/cys-flr.test.ts
+++ b/tests/cys-flr.test.ts
@@ -12,7 +12,7 @@ import { handleTransfer, clamp0, eligibleBalance, getOrCreateVaultBalance } from
 import { getOrCreateAccount } from "../src/common";
 import { getLiquidityV3OwnerBalanceId } from "../src/liquidity";
 import { dataSourceMock } from "matchstick-as";
-import { createTransferEvent, mockLog, mockFactory, mockFactoryRevert, defaultAddressBytes, defaultIntBytes, defaultBigInt, defaultEventDataLogType, mockIncreaseLiquidityLog, mockSlot0, mockLiquidityV3Positions, mockLiquidityV2Pairs } from "./utils";
+import { createTransferEvent, mockLog, mockFactory, mockFactoryRevert, defaultAddress, defaultAddressBytes, defaultIntBytes, defaultBigInt, defaultEventDataLogType, mockIncreaseLiquidityLog, mockSlot0, mockLiquidityV3Positions, mockLiquidityV2Pairs } from "./utils";
 import { SparkdexV3LiquidityManager, DecreaseLiquidityV3ABI, V3_POOL_FACTORIES } from "../src/constants";
 import { ethereum, Wrapped } from "@graphprotocol/graph-ts";
 
@@ -52,6 +52,12 @@ describe("Transfer handling", () => {
     mockFactoryRevert(USER_1);
     mockFactoryRevert(USER_2);
     mockFactoryRevert(ZERO_ADDRESS);
+    // newMockEvent defaults transaction.to to this address — handleTransfer
+    // now calls isApprovedSource on tx.to, which calls factory(). Mock it
+    // to revert so isApprovedSource returns false.
+    mockFactoryRevert(defaultAddress);
+    mockFactoryRevert(SparkdexV3LiquidityManager);
+    mockFactoryRevert(UNAPPROVED_DEX);
     mockFactory(APPROVED_DEX_ROUTER, Address.fromString("0x16b619B04c961E8f4F06C10B42FDAbb328980A89")); // Valid V2 factory
     mockFactory(APPROVED_DEX_POOL, V3_POOL_FACTORIES[0]); // Valid V3 factory
     mockSlot0(APPROVED_DEX_POOL, -500);
@@ -811,6 +817,9 @@ describe("boughtCap/lpBalance eligibility model", () => {
     dataSourceMock.setNetwork("flare");
     mockFactoryRevert(USER_1);
     mockFactoryRevert(USER_2);
+    mockFactoryRevert(defaultAddress);
+    mockFactoryRevert(SparkdexV3LiquidityManager);
+    mockFactoryRevert(UNAPPROVED_DEX);
     mockFactory(APPROVED_DEX_POOL, V3_POOL_FACTORIES[0]);
     mockSlot0(APPROVED_DEX_POOL, -500);
     mockLiquidityV2Pairs(APPROVED_DEX_POOL, CYSFLR_ADDRESS, CYWETH_ADDRESS);
@@ -1092,6 +1101,67 @@ describe("boughtCap/lpBalance eligibility model", () => {
     assert.fieldEquals("VaultBalance", cyWETHVbId, "boughtCap", "300");
     assert.fieldEquals("VaultBalance", cyWETHVbId, "lpBalance", "300");
     assert.fieldEquals("VaultBalance", cyWETHVbId, "balance", "300");
+  });
+
+  test("Receive from unapproved intermediate with approved tx.to credits boughtCap (aggregator routing)", () => {
+    // Aggregators like OpenOcean may route cy-token trades through an
+    // intermediate contract. The Transfer.from is the intermediate (not
+    // approved), but tx.to is the aggregator (approved). The recipient should
+    // still be credited.
+    clearStore();
+
+    let aggregatorTrade = createTransferEvent(
+      UNAPPROVED_DEX, // Transfer.from — unknown intermediate contract
+      USER_1,
+      BigInt.fromI32(500),
+      CYSFLR_ADDRESS,
+      null,
+      USER_1, // tx.from
+      APPROVED_DEX_ROUTER, // tx.to — approved aggregator
+    );
+    handleTransfer(aggregatorTrade);
+
+    const vbId = CYSFLR_ADDRESS.concat(USER_1).toHexString();
+    assert.fieldEquals("VaultBalance", vbId, "boughtCap", "500");
+    assert.fieldEquals(
+      "Transfer",
+      aggregatorTrade.transaction.hash.concatI32(aggregatorTrade.logIndex.toI32()).toHexString(),
+      "txToIsApprovedSource",
+      "true",
+    );
+    assert.fieldEquals(
+      "Transfer",
+      aggregatorTrade.transaction.hash.concatI32(aggregatorTrade.logIndex.toI32()).toHexString(),
+      "fromIsApprovedSource",
+      "false",
+    );
+  });
+
+  test("Receive from unapproved intermediate with unapproved tx.to does NOT credit boughtCap", () => {
+    // Control: unapproved Transfer.from AND unapproved tx.to = wallet-to-wallet
+    // transfer. Recipient's boughtCap should NOT be credited; sender's
+    // boughtCap goes negative.
+    clearStore();
+
+    let peerTransfer = createTransferEvent(
+      USER_2,
+      USER_1,
+      BigInt.fromI32(500),
+      CYSFLR_ADDRESS,
+      null,
+      USER_2,
+      USER_2, // tx.to not approved
+    );
+    handleTransfer(peerTransfer);
+
+    const vbId = CYSFLR_ADDRESS.concat(USER_1).toHexString();
+    assert.fieldEquals("VaultBalance", vbId, "boughtCap", "0");
+    assert.fieldEquals(
+      "Transfer",
+      peerTransfer.transaction.hash.concatI32(peerTransfer.logIndex.toI32()).toHexString(),
+      "txToIsApprovedSource",
+      "false",
+    );
   });
 
   test("LP deposit to cy/cy pool with equal amounts credits correct token", () => {


### PR DESCRIPTION
## Summary

DEX aggregators (e.g. OpenOcean) may route cy-token buys through an intermediate adapter contract. Under the old rule, these aggregator-routed trades left the buyer with \`boughtCap=0\` because \`Transfer.from\` is the unrecognized adapter, not the aggregator.

## Changes

- Add \`txTo\` (optional Bytes) and \`txToIsApprovedSource\` (Boolean) to the \`Transfer\` entity
- In \`handleTransfer\`, compute an \`isApprovedBuy\` flag as \`fromIsApprovedSource OR txToIsApprovedSource\` and credit \`boughtCap\` accordingly
- Short-circuit to skip redundant \`factory()\` calls when \`fromIsApprovedSource\` is already true, or when \`txTo\` is null, or when \`txTo == event.address\` (the cy token itself, never approved)

## Tests

- Adds two new tests exercising the txTo path (approved-aggregator credit + unapproved control)
- Updates existing test setup to mock \`factory()\` revert on \`defaultAddress\` and \`SparkdexV3LiquidityManager\` (required because handler now calls \`isApprovedSource(txTo)\` even when \`from\` is an internal/EOA address)
- **109 matchstick tests pass locally**

## Paired with

[cyclofinance/cyclo.rewards#???](https://github.com/cyclofinance/cyclo.rewards/pulls) — rewards pipeline consumes the new \`txTo\` field.

## Context

Investigation: cyclofinance/cyclo.rewards#215 — an LP with 12k cysFLR LP'd via Sparkdex but earned zero because their OpenOcean-routed cysFLR purchases went through an unrecognized intermediate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)